### PR TITLE
feat(k8s): Update Kong deployment configuration and module references

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,15 +161,9 @@ The infrastructure deploys Kong with Gateway API v1.0.0 support:
 
 ```hcl
 deploy_kong = {
-  dev = {
-    version = "2.48.0"
+  kong = {
+    version             = "2.52.0"
     gateway_api_enabled = true
-    additional_set = [
-      {
-        name  = "ingressController.gatewayAPI.enabled"
-        value = "true"
-      }
-    ]
   }
 }
 ```

--- a/modules/k8s/cluster/main.tf
+++ b/modules/k8s/cluster/main.tf
@@ -17,11 +17,12 @@ module "homelab_cluster" {
 }
 
 module "homelab_cluster_config" {
-  source = "github.com/devops-homelab/homelab-terraform-modules.git//digitalocean/kubernetes/config/?ref=v3.9.0"
+  source = "github.com/devops-homelab/homelab-terraform-modules.git//digitalocean/kubernetes/config/?ref=main"
 
   deploy_kong = {
     kong = {
-      version          = "2.52.0"
+      version             = "2.52.0"
+      gateway_api_enabled = true
     }
   }
 

--- a/modules/k8s/cluster/versions.tf
+++ b/modules/k8s/cluster/versions.tf
@@ -11,8 +11,8 @@ provider "kubernetes" {
 
 provider "helm" {
   kubernetes {
-    host  = module.homelab_cluster.endpoint[0]
-    token = module.homelab_cluster.token[0]
+    host                   = module.homelab_cluster.endpoint[0]
+    token                  = module.homelab_cluster.token[0]
     cluster_ca_certificate = base64decode(
       module.homelab_cluster.cluster_ca_certificate[0]
     )

--- a/modules/k8s/cluster/versions.tf
+++ b/modules/k8s/cluster/versions.tf
@@ -28,6 +28,7 @@ provider "kubectl" {
   load_config_file = false
 }
 
+
 terraform {
   required_providers {
     kubectl = {

--- a/modules/k8s/cluster/versions.tf
+++ b/modules/k8s/cluster/versions.tf
@@ -28,7 +28,6 @@ provider "kubectl" {
   load_config_file = false
 }
 
-
 terraform {
   required_providers {
     kubectl = {


### PR DESCRIPTION
- Update Kong version from "2.48.0" to "2.52.0"
- Enable Gateway API support in Kong configuration
- Update Kubernetes config module source to use 'main' branch
- Simplify Kong deployment configuration in README and main.tf
- Update Helm provider configuration with more explicit formatting